### PR TITLE
Prefer #current over #now for times in Rails

### DIFF
--- a/lib/time_for_a_boolean.rb
+++ b/lib/time_for_a_boolean.rb
@@ -6,12 +6,12 @@ module TimeForABoolean
   def time_for_a_boolean(attribute)
     define_method(attribute) do
       !send("#{attribute}_at").nil? &&
-        send("#{attribute}_at") <= -> { DateTime.now }.()
+        send("#{attribute}_at") <= -> { DateTime.current }.()
     end
     alias_method "#{attribute}?", attribute
     define_method("#{attribute}=") do |value|
       if value
-        send("#{attribute}_at=", -> { DateTime.now }.())
+        send("#{attribute}_at=", -> { DateTime.current }.())
       else
         send("#{attribute}_at=", nil)
       end


### PR DESCRIPTION
- My understanding is this is preferred for Rails dependent code as it
  will make it more resilliant against tz issues.
- http://stackoverflow.com/questions/6635363/what-is-the-difference-between-date-current-and-date-today

---

Your gem came up in discussion in our chatroom. I couldn't resist a peak. Further I could resist the urge to give back if I noticed anything.

Let me know what you think!
