### PR TITLE
Replace `be_true/false` with `be_truthy/falsey`

### DIFF
--- a/spec/time_for_a_boolean_spec.rb
+++ b/spec/time_for_a_boolean_spec.rb
@@ -37,21 +37,21 @@ describe TimeForABoolean do
       klass.time_for_a_boolean :attribute
       object.stub(attribute_at: DateTime.now - 10)
 
-      expect(object.attribute).to be_true
+      expect(object.attribute).to be_truthy
     end
 
     it 'is false if the attribute is nil' do
       klass.time_for_a_boolean :attribute
       object.stub(attribute_at: nil)
 
-      expect(object.attribute).to be_false
+      expect(object.attribute).to be_falsey
     end
 
     it 'is false if the attribute time is in the future' do
       klass.time_for_a_boolean :attribute
       object.stub(attribute_at: Time.now + 86400) # one day in the future
 
-      expect(object.attribute).to be_false
+      expect(object.attribute).to be_falsey
     end
   end
 


### PR DESCRIPTION
- This syntax was deprecated in late rspec 2 version and removed in
  rspec 3. I believe it's the cause of some recent ci failures
