### PR TITLE
Use `Time` instead of `DateTime`

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ methods are defined:
 | --------------- | -----------
 | `Post#deleted`  | `true` if `Post#deleted_at` is set to a value greater than `Time.current`, `false` otherwise
 | `Post#deleted?` | Alias for `Post#deleted`
-| `Post#deleted=` | Sets the timestamp to `DateTime.now` if the new value is true, and `nil` otherwise
+| `Post#deleted=` | Sets the timestamp to `Time.current` if the new value is true, and `nil` otherwise
 
 These methods allow you to use a timestamp as you would a boolean value in your
 application.

--- a/lib/time_for_a_boolean.rb
+++ b/lib/time_for_a_boolean.rb
@@ -6,12 +6,12 @@ module TimeForABoolean
   def time_for_a_boolean(attribute)
     define_method(attribute) do
       !send("#{attribute}_at").nil? &&
-        send("#{attribute}_at") <= -> { DateTime.current }.()
+        send("#{attribute}_at") <= -> { Time.current }.()
     end
     alias_method "#{attribute}?", attribute
     define_method("#{attribute}=") do |value|
       if ActiveRecord::ConnectionAdapters::Column::TRUE_VALUES.include?(value)
-        send("#{attribute}_at=", -> { DateTime.current }.())
+        send("#{attribute}_at=", -> { Time.current }.())
       else
         send("#{attribute}_at=", nil)
       end

--- a/spec/time_for_a_boolean_spec.rb
+++ b/spec/time_for_a_boolean_spec.rb
@@ -35,7 +35,7 @@ describe TimeForABoolean do
 
     it 'is true if the attribute is not nil' do
       klass.time_for_a_boolean :attribute
-      allow(object).to receive(:attribute_at).and_return(DateTime.now - 10)
+      allow(object).to receive(:attribute_at).and_return(Time.now - 10)
 
       expect(object.attribute).to be_truthy
     end
@@ -70,14 +70,14 @@ describe TimeForABoolean do
 
       object.attribute = true
 
-      expect(object.attribute_at).to be_kind_of(DateTime)
+      expect(object.attribute_at).to be_kind_of(Time)
     end
 
     it 'sets the timestamp to nil if value is false' do
       klass.time_for_a_boolean :attribute
       klass.send(:attr_accessor, :attribute_at)
 
-      object.attribute_at = DateTime.now
+      object.attribute_at = Time.now
       object.attribute = false
 
       expect(object.attribute_at).to be_nil
@@ -89,14 +89,14 @@ describe TimeForABoolean do
 
       object.attribute = '1'
 
-      expect(object.attribute_at).to be_kind_of(DateTime)
+      expect(object.attribute_at).to be_kind_of(Time)
     end
 
     it 'works with other representations of false' do
       klass.time_for_a_boolean :attribute
       klass.send(:attr_accessor, :attribute_at)
 
-      object.attribute_at = DateTime.now
+      object.attribute_at = Time.now
       object.attribute = '0'
 
       expect(object.attribute_at).to be_nil


### PR DESCRIPTION
Timestamp columns in ActiveRecord map to `Time`, not `DateTime`. While
Active Record performs the conversion automatically, there have been
obscure issues in the past related to using `DateTime`.
