### PR TITLE
WIP: Switch to using Rails 5 false values instead of true

### DIFF
--- a/lib/time_for_a_boolean.rb
+++ b/lib/time_for_a_boolean.rb
@@ -1,5 +1,6 @@
 require "active_support/core_ext/module/delegation"
-require "active_record/connection_adapters/column"
+require "active_support/core_ext/time/calculations"
+require "active_model/type"
 require "time_for_a_boolean/version"
 require "time_for_a_boolean/railtie"
 
@@ -13,10 +14,10 @@ module TimeForABoolean
 
     setter_attribute = "#{field}="
     define_method("#{attribute}=") do |value|
-      if ActiveRecord::ConnectionAdapters::Column::TRUE_VALUES.include?(value)
-        send(setter_attribute, -> { Time.current }.())
-      else
+      if ActiveModel::Type::Boolean::FALSE_VALUES.include?(value)
         send(setter_attribute, nil)
+      else
+        send(setter_attribute, -> { Time.current }.())
       end
     end
   end


### PR DESCRIPTION
First, rails removed TRUE_VALUES, leaving FALSE_VALUES: https://github.com/rails/rails/commit/a502703c3d2151d4d3b421b29fefdac5ad05df61

Then, the file containing FALSE_VALUES was moved to ActiveModel: https://github.com/rails/rails/commit/9cc8c6f3730df3d94c81a55be9ee1b7b4ffd29f6#diff-9a8a85e0f8b322dc1f9bd9c460c204b8

I decided to use the new FALSE_VALUES constant and switch the conditional around to maintain old behavior.

fixes: #10 

Note: I'm not super comfortable with creating gems that extend active record/model behavior. This is my best attempt to make the tests pass while changing as little as possible.