### PR TITLE
Set the current timestamp with `attribute!`

### DIFF
--- a/lib/time_for_a_boolean.rb
+++ b/lib/time_for_a_boolean.rb
@@ -20,5 +20,9 @@ module TimeForABoolean
         send(setter_attribute, -> { Time.current }.())
       end
     end
+
+    define_method("#{attribute}!") do
+      send(setter_attribute, -> { Time.current }.())
+    end
   end
 end

--- a/spec/time_for_a_boolean_spec.rb
+++ b/spec/time_for_a_boolean_spec.rb
@@ -22,6 +22,12 @@ describe TimeForABoolean do
     expect(klass.new).to respond_to :attribute=
   end
 
+  it 'defines the bangable method to act as an implicit writer' do
+    klass.time_for_a_boolean :attribute
+
+    expect(klass.new).to respond_to :attribute!
+  end
+
   describe 'attribute method' do
     it 'calls nil? on the backing timestamp' do
       klass.time_for_a_boolean :attribute
@@ -133,6 +139,17 @@ describe TimeForABoolean do
       object.attribute = '0'
 
       expect(object.attribute_at).to be_nil
+    end
+  end
+
+  describe 'the bangable method' do
+    it 'sets the timestamp to now' do
+      klass.time_for_a_boolean :attribute
+      klass.send(:attr_accessor, :attribute_at)
+
+      object.attribute!
+
+      expect(object.attribute_at).to be_kind_of(Time)
     end
   end
 


### PR DESCRIPTION
This allows setting the `attribute` to the current timestamp using a
shorter syntax, which could make a snippet such as this possible:

```ruby
current_user.posts.each(&:delete!)
```

Rather than writing out the full form:

```ruby
current_user.posts.each { |post| post.delete = true }
```