### PR TITLE
Pass `Range` instances to scopes

### DIFF
--- a/lib/time_for_a_boolean.rb
+++ b/lib/time_for_a_boolean.rb
@@ -29,11 +29,11 @@ module TimeForABoolean
     if scopes && respond_to?(:where)
       singleton_class.instance_eval do
         define_method(:"#{attribute}") do
-          where.not("#{field}": nil).where("#{field} <= ?", Time.current)
+          where(field => ..Time.current)
         end
 
         define_method(:"not_#{attribute}") do
-          where("#{field}": nil).or(where("#{field} > ?", Time.current))
+          where(field => [nil, Time.current...])
         end
       end
     end


### PR DESCRIPTION
Follow-up to [#17][]

Utilizing Range instance arguments for the [where][] calls presents the possibility of relying on Active Record to construct the underlying `<=`, `>`, and `OR` expressions.

Replace the inline SQL strings with [beginless][] and [endless][] ranges. The end-inclusive `..` variation replaces `<=`, and the end-exclusive `...` variation replaces `>`.

**Note** The absence of Active Record integration tests makes this change a little risky. Without test coverage, having knowledge of the query API is the only way to be confident that this behaves as outlined. I've tested this commit in an application's test suite, so can vouch for its behavior. Having said that, I think including Active Record integration tests in this project's suite would be a net benefit (in spite of whatever test harness costs would be incurred). I'm happy to explore that in a separate PR if you're open to that!

[#17]: https://github.com/calebhearth/time_for_a_boolean/pull/17
[where]: https://edgeapi.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-where
[beginless]: https://docs.ruby-lang.org/en/3.3/Range.html#class-Range-label-Beginless+Ranges
[endless]: https://docs.ruby-lang.org/en/3.3/Range.html#class-Range-label-Endless+Ranges